### PR TITLE
PAC-73 feature/menu home

### DIFF
--- a/assets/images/exit.svg
+++ b/assets/images/exit.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 17L21 12L16 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 12H9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,11 +5,15 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -18,11 +22,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
 
 PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,10 +12,12 @@ class App extends StatefulWidget {
 
 class _AppState extends State<App> {
   bool isDarkMode = false;
+  late ValueNotifier<bool> isDarkModeNotifier;
 
   @override
   void initState() {
     super.initState();
+    isDarkModeNotifier = ValueNotifier<bool>(isDarkMode);
     _loadThemePreference();
   }
 
@@ -23,6 +25,7 @@ class _AppState extends State<App> {
     final prefs = await SharedPreferences.getInstance();
     setState(() {
       isDarkMode = prefs.getBool('isDarkMode') ?? false;
+      isDarkModeNotifier.value = isDarkMode;
     });
   }
 
@@ -34,6 +37,7 @@ class _AppState extends State<App> {
   void _toggleTheme(bool value) {
     setState(() {
       isDarkMode = value;
+      isDarkModeNotifier.value = value;
       _saveThemePreference(value);
     });
   }
@@ -76,7 +80,7 @@ class _AppState extends State<App> {
       themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
       home: LoginScreen(
         onThemeToggle: _toggleTheme,
-        isDarkMode: isDarkMode,
+        isDarkModeNotifier: isDarkModeNotifier,
       ),
     );
   }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,100 +1,83 @@
 import 'package:flutter/material.dart';
-// import 'package:softwareipj_app/screens/create_members.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:softwareipj_app/screens/home.dart';
 import 'package:softwareipj_app/screens/login.dart';
-// import 'package:softwareipj_app/screens/report.dart';
-// import 'package:softwareipj_app/screens/start_screen.dart';
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({super.key});
+
+  @override
+  _AppState createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  bool isDarkMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadThemePreference();
+  }
+
+  Future<void> _loadThemePreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      isDarkMode = prefs.getBool('isDarkMode') ?? false;
+    });
+  }
+
+  Future<void> _saveThemePreference(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('isDarkMode', value);
+  }
+
+  void _toggleTheme(bool value) {
+    setState(() {
+      isDarkMode = value;
+      _saveThemePreference(value);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
-        fontFamily: 'Poppins', // Define a Poppins como fonte padrão
-        scaffoldBackgroundColor: const Color(0xFFFCF9F6), // Cor de fundo para o modo claro
-        primaryColor: const Color(0xFF015B40), // Cor primária para o modo claro
-        brightness: Brightness.light, // Define o brilho como claro
+        fontFamily: 'Poppins',
+        scaffoldBackgroundColor: const Color(0xFFFCF9F6),
+        primaryColor: const Color(0xFF015B40),
+        brightness: Brightness.light,
         textTheme: const TextTheme(
-          bodyLarge: TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.normal,
-            color: Colors.black, // Texto preto quando preenchido no modo claro
-          ),
-          bodyMedium: TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.normal,
-            color: Colors.grey, // Cor inicial (cinza) para os campos vazios
-          ),
-          titleMedium: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.w500,
-            color: Color(0xFF015B40), // Cor verde
-          ),
-          titleLarge: TextStyle(
-            //Classe para os titulos de cabeçalhos
-            fontSize: 24,
-            fontWeight: FontWeight.w600,
-            color: Color.fromARGB(255, 255, 255, 255),
-          ),
+          bodyLarge: TextStyle(fontSize: 14, fontWeight: FontWeight.normal, color: Colors.black),
+          bodyMedium: TextStyle(fontSize: 14, fontWeight: FontWeight.normal, color: Colors.grey),
+          titleMedium: TextStyle(fontSize: 18, fontWeight: FontWeight.w500, color: Color(0xFF015B40)),
+          titleLarge: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, color: Color.fromARGB(255, 255, 255, 255)),
         ),
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFF015B40), // Cor do AppBar no modo claro
-        ),
-        inputDecorationTheme: const InputDecorationTheme(
-          fillColor: Color(0xFFE7E7E7), // Cor de fundo dos campos no modo claro
-          filled: true, // Garante que a cor de fundo seja aplicada
-        ),
-        iconTheme: const IconThemeData(
-          color: Color(0xFF015B40), // Cor para os ícones no modo claro
-        ),
-        colorScheme: const ColorScheme.light(
-          primary: Color(0xFF015B40), // Cor primária no modo claro
-          secondary: Color.fromARGB(255, 0, 145, 101), // Cor secundária no modo claro
-        ),
+        appBarTheme: const AppBarTheme(backgroundColor: Color(0xFF015B40)),
+        inputDecorationTheme: const InputDecorationTheme(fillColor: Color(0xFFE7E7E7), filled: true),
+        iconTheme: const IconThemeData(color: Color(0xFF015B40)),
+        colorScheme: const ColorScheme.light(primary: Color(0xFF015B40), secondary: Color.fromARGB(255, 0, 145, 101)),
       ),
       darkTheme: ThemeData(
-        fontFamily: 'Poppins', // Define a Poppins como fonte padrão
-        scaffoldBackgroundColor: const Color.fromARGB(255, 0, 0, 0), // Cor de fundo para o modo escuro
-        primaryColor: const Color.fromARGB(255, 0, 145, 101), // Cor do rótulo quando o campo está focado
-        brightness: Brightness.dark, // Define o brilho como escuro
+        fontFamily: 'Poppins',
+        scaffoldBackgroundColor: const Color.fromARGB(255, 0, 0, 0),
+        primaryColor: const Color.fromARGB(255, 0, 145, 101),
+        brightness: Brightness.dark,
         textTheme: const TextTheme(
-          bodyLarge: TextStyle(
-            fontSize: 14,
-            color: Colors.white, // Texto branco quando preenchido no modo escuro
-          ),
-          bodyMedium: TextStyle(
-            fontSize: 14,
-            color: Colors.grey, // Texto cinza quando vazio no modo escuro
-          ),
-          titleMedium: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.w500,
-            color: Colors.white, // Títulos no modo escuro
-          ),
-          titleLarge: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.w600,
-            color: Color.fromARGB(255, 255, 255, 255), // Títulos no modo escuro
-          ),
+          bodyLarge: TextStyle(fontSize: 14, color: Colors.white),
+          bodyMedium: TextStyle(fontSize: 14, color: Colors.grey),
+          titleMedium: TextStyle(fontSize: 18, fontWeight: FontWeight.w500, color: Colors.white),
+          titleLarge: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, color: Color.fromARGB(255, 255, 255, 255)),
         ),
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFF1F1F1F), // Cor do AppBar no modo escuro
-        ),
-        inputDecorationTheme: const InputDecorationTheme(
-          fillColor: Color(0xFF1F1F1F), // Cor de fundo dos campos no modo escuro
-          filled: true, // Garante que a cor de fundo seja aplicada
-        ),
-        iconTheme: const IconThemeData(
-          color: Colors.white, // Cor branca para o ícone (logo) no modo escuro
-        ),
-        colorScheme: const ColorScheme.dark(
-          primary: Color.fromARGB(255, 45, 45, 45), // Cor primária no modo escuro
-          secondary: Color(0xFF015B40), // Cor secundária no modo escuro
-        ),
+        appBarTheme: const AppBarTheme(backgroundColor: Color(0xFF1F1F1F)),
+        inputDecorationTheme: const InputDecorationTheme(fillColor: Color(0xFF1F1F1F), filled: true),
+        iconTheme: const IconThemeData(color: Colors.white),
+        colorScheme: const ColorScheme.dark(primary: Color.fromARGB(255, 45, 45, 45), secondary: Color(0xFF015B40)),
       ),
-      themeMode: ThemeMode.system, // Altere para ThemeMode.system para seguir o tema do sistema
-      home: LoginScreen(),
+      themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
+      home: LoginScreen(
+        onThemeToggle: _toggleTheme,
+        isDarkMode: isDarkMode,
+      ),
     );
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:softwareipj_app/screens/home.dart';
 import 'package:softwareipj_app/screens/login.dart';
+import 'package:softwareipj_app/screens/start_screen.dart';
 
 class App extends StatefulWidget {
   const App({super.key});
@@ -78,10 +79,11 @@ class _AppState extends State<App> {
         colorScheme: const ColorScheme.dark(primary: Color.fromARGB(255, 45, 45, 45), secondary: Color(0xFF015B40)),
       ),
       themeMode: isDarkMode ? ThemeMode.dark : ThemeMode.light,
-      home: LoginScreen(
-        onThemeToggle: _toggleTheme,
-        isDarkModeNotifier: isDarkModeNotifier,
-      ),
+      home: StartScreen(onThemeToggle: _toggleTheme, isDarkModeNotifier: isDarkModeNotifier),
+      // home: LoginScreen(
+      //   onThemeToggle: _toggleTheme,
+      //   isDarkModeNotifier: isDarkModeNotifier,
+      // ),
     );
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:softwareipj_app/screens/report.dart';
 import '../widgets/card_register.dart';
 import '../widgets/card_members.dart';
 import '../widgets/card_report_home.dart';
 import '../widgets/card_count_members.dart';
 import '../widgets/custom_drawer.dart';
-import '../screens/report.dart'; // Importe o ReportScreen
 
 class HomeScreen extends StatefulWidget {
-  final Function(bool)? onThemeToggle; // Torne onThemeToggle opcional
-  final bool isDarkMode;
+  final Function(bool) onThemeToggle;
+  final ValueNotifier<bool> isDarkModeNotifier;
 
   const HomeScreen({
     super.key,
-    this.onThemeToggle, // Agora opcional
-    this.isDarkMode = false, // Valor padrão para isDarkMode
+    required this.onThemeToggle,
+    required this.isDarkModeNotifier,
   });
 
   @override
@@ -60,8 +60,8 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
       drawer: CustomDrawer(
-        onThemeToggle: widget.onThemeToggle ?? (bool value) {},
-        isDarkMode: widget.isDarkMode,
+        onThemeToggle: widget.onThemeToggle,
+        isDarkModeNotifier: widget.isDarkModeNotifier,
       ), // Utilize o CustomDrawer como menu lateral
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(20.0),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,11 +2,25 @@ import 'package:flutter/material.dart';
 import '../widgets/card_register.dart';
 import '../widgets/card_members.dart';
 import '../widgets/card_report_home.dart';
-import '../widgets/card_count_members.dart'; // Importe o novo widget
+import '../widgets/card_count_members.dart';
+import '../widgets/custom_drawer.dart';
+import '../screens/report.dart'; // Importe o ReportScreen
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class HomeScreen extends StatefulWidget {
+  final Function(bool)? onThemeToggle; // Torne onThemeToggle opcional
+  final bool isDarkMode;
 
+  const HomeScreen({
+    super.key,
+    this.onThemeToggle, // Agora opcional
+    this.isDarkMode = false, // Valor padrão para isDarkMode
+  });
+
+  @override
+  _HomeScreenState createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -14,15 +28,23 @@ class HomeScreen extends StatelessWidget {
         toolbarHeight: 90,
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         scrolledUnderElevation: 0,
-        leading: IconButton(
-          onPressed: () {
-            Scaffold.of(context).openDrawer(); // Abre o menu lateral
+        leading: Builder(
+          builder: (context) {
+            return IconButton(
+              onPressed: () {
+                Scaffold.of(context).openDrawer(); // Abre o menu lateral
+              },
+              icon: Icon(
+                Icons.menu,
+                size: 30,
+                color: Theme.of(context).iconTheme.color,
+              ),
+              splashColor: Colors.transparent, // Remove a sombra ao clicar
+              highlightColor: Colors.transparent, // Remove o destaque ao clicar
+              focusColor: Colors.transparent, // Remove o destaque ao focar
+              hoverColor: Colors.transparent, // Remove o destaque ao passar o mouse por cima
+            );
           },
-          icon: Icon(
-            Icons.menu,
-            size: 30,
-            color: Theme.of(context).iconTheme.color,
-          ),
         ),
         centerTitle: true,
         title: Row(
@@ -37,30 +59,44 @@ class HomeScreen extends StatelessWidget {
           ],
         ),
       ),
-      body: const SingleChildScrollView(
-        padding: EdgeInsets.all(20.0),
+      drawer: CustomDrawer(
+        onThemeToggle: widget.onThemeToggle ?? (bool value) {},
+        isDarkMode: widget.isDarkMode,
+      ), // Utilize o CustomDrawer como menu lateral
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             // Card de cadastro de membros, ocupando toda a largura
-            CardRegister(),
-            SizedBox(height: 29),
+            const CardRegister(),
+            const SizedBox(height: 29),
             // Cards de membros e relatório na mesma linha, ocupando cada um metade da largura do card acima
             Row(
               children: [
-                Expanded(
+                const Expanded(
                   child: CardMembers(),
                 ),
-                SizedBox(width: 29), // Espaço entre os dois cards
+                const SizedBox(width: 29), // Espaço entre os dois cards
                 Expanded(
-                  child: CardReport(),
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const Report(), // Navega para a tela de relatório ao clicar no CardReport
+                        ),
+                      );
+                    },
+                    child: const CardReport(),
+                  ),
                 ),
               ],
             ),
-            SizedBox(height: 29),
+            const SizedBox(height: 29),
             // Adicionando o card de contagem de membros
-            MembersCountCard(),
+            const MembersCountCard(),
           ],
         ),
       ),

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart'; // Importa o pacote flutter_svg
-import 'package:softwareipj_app/screens/report.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:softwareipj_app/screens/home.dart';
 import '../widgets/custom_text_field.dart';
 import '../widgets/custom_button.dart';
-import 'dart:ui'; // Necessário para o BackdropFilter
+import 'dart:ui';
 
 class LoginScreen extends StatelessWidget {
   final TextEditingController loginController = TextEditingController();
@@ -11,56 +11,56 @@ class LoginScreen extends StatelessWidget {
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
   final ValueNotifier<String> errorMessage = ValueNotifier<String>("");
 
-  LoginScreen({super.key});
+  final void Function(bool value) onThemeToggle;
+  final bool isDarkMode;
 
-  // Função de login, verifica as credenciais
+  LoginScreen({
+    super.key,
+    required this.onThemeToggle,
+    required this.isDarkMode,
+  });
+
   void login(BuildContext context) async {
     String usuario = loginController.text;
     String senha = passwordController.text;
 
-    // Verificação de usuário e senha
-    if (usuario == "ipj" && senha == "ipj") {
-      // Navega para a tela Home usando o Navigator.push
-      Navigator.push(
+    if (usuario == "" && senha == "") {
+      Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (context) => const Report()),
+        MaterialPageRoute(
+          builder: (context) => HomeScreen(
+            onThemeToggle: onThemeToggle,
+            isDarkMode: isDarkMode,
+          ),
+        ),
       );
     } else {
-      // Exibe uma mensagem de erro
       errorMessage.value = "Usuário ou senha incorreto! Verifique suas informações e tente novamente.";
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    // Verifica se o tema é escuro ou claro
-    final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
-
-    // Define a cor de fundo com opacidade apenas no modo escuro
-    final Color backgroundWithOpacity = isDarkMode
-        ? Colors.black.withOpacity(0.75) // Escurece no modo escuro
-        : Colors.transparent; // Sem opacidade no modo claro (imagem original)
+    final bool isDarkTheme = Theme.of(context).brightness == Brightness.dark;
+    final Color backgroundWithOpacity = isDarkTheme
+        ? Colors.black.withOpacity(0.75)
+        : Colors.transparent;
 
     return Scaffold(
       body: Stack(
         children: [
-          // Imagem de fundo
           Positioned.fill(
             child: Image.asset(
               'assets/images/Igreja_Fundo_Login.jpg',
               fit: BoxFit.cover,
             ),
           ),
-          // Aplica desfoque e cor de fundo apenas no modo escuro
           Positioned.fill(
             child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0), // Efeito fosco para ambos os temas
-              child: Container(
-                color: backgroundWithOpacity, // Aplica o fundo escuro com opacidade apenas no modo escuro
-              ),
+              filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
+              child: Container(color: backgroundWithOpacity),
             ),
           ),
-          // Logo da empresa
           Positioned(
             top: 100,
             left: 0,
@@ -69,12 +69,10 @@ class LoginScreen extends StatelessWidget {
               child: Image.asset(
                 'assets/images/Logo_IPB.png',
                 height: 100,
-                color: Theme.of(context).primaryColor, // Acessa a cor definida no iconTheme
-
+                color: Theme.of(context).primaryColor,
               ),
             ),
           ),
-          // Formulário de login
           Center(
             child: SingleChildScrollView(
               child: Padding(
@@ -84,10 +82,9 @@ class LoginScreen extends StatelessWidget {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      const SizedBox(height: 150), // Espaço entre a logo e os campos
-                      // Campo de Login com largura ajustada
+                      const SizedBox(height: 150),
                       SizedBox(
-                        width: 300, // Ajuste a largura do campo de texto aqui
+                        width: 300,
                         child: CustomTextField(
                           controller: loginController,
                           hintText: 'Login',
@@ -100,9 +97,8 @@ class LoginScreen extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(height: 20),
-                      // Campo de Senha com largura ajustada
                       SizedBox(
-                        width: 300, // Ajuste a largura do campo de texto aqui
+                        width: 300,
                         child: CustomTextField(
                           controller: passwordController,
                           hintText: 'Senha',
@@ -114,17 +110,17 @@ class LoginScreen extends StatelessWidget {
                           ),
                         ),
                       ),
-                      const SizedBox(height: 40), // Espaço antes do botão de login
+                      const SizedBox(height: 40),
                       CustomButton(
                         text: 'Entrar',
-                        onPressed: () => login(context), // Chama a função login no onPressed
+                        onPressed: () => login(context),
                       ),
                       const SizedBox(height: 20),
                       ValueListenableBuilder(
                         valueListenable: errorMessage,
                         builder: (context, value, child) {
                           return Text(
-                            textAlign: TextAlign.center, // Centraliza o texto
+                            textAlign: TextAlign.center,
                             value,
                             style: const TextStyle(
                               color: Colors.red,

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -12,12 +12,12 @@ class LoginScreen extends StatelessWidget {
   final ValueNotifier<String> errorMessage = ValueNotifier<String>("");
 
   final void Function(bool value) onThemeToggle;
-  final bool isDarkMode;
+  final ValueNotifier<bool> isDarkModeNotifier;
 
   LoginScreen({
     super.key,
     required this.onThemeToggle,
-    required this.isDarkMode,
+    required this.isDarkModeNotifier,
   });
 
   void login(BuildContext context) async {
@@ -30,7 +30,7 @@ class LoginScreen extends StatelessWidget {
         MaterialPageRoute(
           builder: (context) => HomeScreen(
             onThemeToggle: onThemeToggle,
-            isDarkMode: isDarkMode,
+            isDarkModeNotifier: isDarkModeNotifier,
           ),
         ),
       );

--- a/lib/screens/report.dart
+++ b/lib/screens/report.dart
@@ -4,7 +4,7 @@ import '../utils/constants/app_colors.dart';
 import '../widgets/card_report.dart';
 
 class Report extends StatelessWidget {
-  const Report({super.key});
+  const Report({super.key, Function(bool p1)? onThemeToggle, bool? isDarkMode});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 import 'login.dart'; // Certifique-se de importar a tela de login
 
-
 class StartScreen extends StatefulWidget {
-  const StartScreen({super.key});
+  final void Function(bool) onThemeToggle;
+  final ValueNotifier<bool> isDarkModeNotifier;
+
+  const StartScreen({
+    super.key,
+    required this.onThemeToggle,
+    required this.isDarkModeNotifier,
+  });
 
   @override
   _StartScreenState createState() => _StartScreenState();
@@ -21,8 +27,10 @@ class _StartScreenState extends State<StartScreen> {
         context,
         PageRouteBuilder(
           transitionDuration: const Duration(milliseconds: 600), // Duração da animação de transição
-          pageBuilder: (context, animation, secondaryAnimation) => LoginScreen(onThemeToggle: widget.onThemeToggle,
-                  isDarkModeNotifier: widget.isDarkModeNotifier,),
+          pageBuilder: (context, animation, secondaryAnimation) => LoginScreen(
+            onThemeToggle: widget.onThemeToggle,
+            isDarkModeNotifier: widget.isDarkModeNotifier,
+          ),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             // Animação de "dissolve" (fade)
             return FadeTransition(

--- a/lib/screens/start_screen.dart
+++ b/lib/screens/start_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'login.dart'; // Certifique-se de importar a tela de login
 
+
 class StartScreen extends StatefulWidget {
   const StartScreen({super.key});
 
@@ -20,7 +21,8 @@ class _StartScreenState extends State<StartScreen> {
         context,
         PageRouteBuilder(
           transitionDuration: const Duration(milliseconds: 600), // Duração da animação de transição
-          pageBuilder: (context, animation, secondaryAnimation) => LoginScreen(),
+          pageBuilder: (context, animation, secondaryAnimation) => LoginScreen(onThemeToggle: widget.onThemeToggle,
+                  isDarkModeNotifier: widget.isDarkModeNotifier,),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             // Animação de "dissolve" (fade)
             return FadeTransition(

--- a/lib/widgets/card_report.dart
+++ b/lib/widgets/card_report.dart
@@ -17,6 +17,7 @@ class _CardReportState extends State<CardReport> {
   @override
   Widget build(BuildContext context) {
     return Container(
+      
       margin: const EdgeInsets.all(10),
       padding: const EdgeInsets.all(16),
       width: 312,

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:softwareipj_app/screens/login.dart';
+
+class CustomDrawer extends StatefulWidget {
+  final Function(bool) onThemeToggle;
+  final bool isDarkMode;
+
+  const CustomDrawer({
+    super.key,
+    required this.onThemeToggle,
+    required this.isDarkMode,
+  });
+
+  @override
+  _CustomDrawerState createState() => _CustomDrawerState();
+}
+
+class _CustomDrawerState extends State<CustomDrawer> {
+  late bool isDarkMode;
+
+  @override
+  void initState() {
+    super.initState();
+    // Inicializa o estado do tema conforme o valor passado do pai
+    isDarkMode = widget.isDarkMode;
+  }
+
+  @override
+  void didUpdateWidget(covariant CustomDrawer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Se o valor do tema for atualizado, sincroniza o estado
+    if (oldWidget.isDarkMode != widget.isDarkMode) {
+      setState(() {
+        isDarkMode = widget.isDarkMode;
+      });
+    }
+  }
+
+  void _handleThemeToggle(bool value) {
+    setState(() {
+      isDarkMode = value;
+    });
+    widget.onThemeToggle(value); // Chama o callback para alterar o tema global
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.6,
+      child: Drawer(
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        child: Column(
+          children: [
+            _buildMenuHeader(),
+            _buildThemeToggle(),
+            _buildLogoutButton(),
+            const Spacer(),
+            _buildAppVersionInfo(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMenuHeader() {
+    return Container(
+      padding: const EdgeInsets.only(top: 50, bottom: 50),
+      child: Align(
+        alignment: Alignment.center,
+        child: Text(
+          'Menu',
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: Colors.white,
+                fontSize: 28,
+              ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildThemeToggle() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: () {
+            _handleThemeToggle(!isDarkMode);
+          },
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              CustomSwitch(
+                value: isDarkMode,
+                onChanged: _handleThemeToggle,
+              ),
+              const SizedBox(width: 20),
+              Text(
+                'Cor do sistema',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: Colors.white,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLogoutButton() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 20.0, horizontal: 16.0),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: () {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (context) => LoginScreen(
+                  onThemeToggle: widget.onThemeToggle,
+                  isDarkMode: isDarkMode,
+                ),
+              ),
+            );
+          },
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SvgPicture.asset(
+                'assets/images/exit.svg',
+                width: 24,
+                height: 24,
+              ),
+              const SizedBox(width: 50),
+              Text(
+                'Sair do app',
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: Colors.white,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAppVersionInfo() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Align(
+        alignment: Alignment.center,
+        child: Text(
+          'v.0.2.0',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Colors.white,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+// Widget personalizado para o Switch com ícone no círculo
+class CustomSwitch extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const CustomSwitch({super.key, required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => onChanged(!value),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        width: 60,
+        height: 30,
+        padding: const EdgeInsets.all(3),
+        decoration: BoxDecoration(
+          color: value ? const Color(0xFF1E1E1E) : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Align(
+          alignment: value ? Alignment.centerRight : Alignment.centerLeft,
+          child: Container(
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: value ? const Color(0xFF585858) : Colors.yellow.shade700,
+            ),
+            child: Icon(
+              value ? Icons.dark_mode : Icons.light_mode,
+              color: value ? const Color(0xFF1E1E1E) : Colors.black,
+              size: 18,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -4,12 +4,12 @@ import 'package:softwareipj_app/screens/login.dart';
 
 class CustomDrawer extends StatefulWidget {
   final Function(bool) onThemeToggle;
-  final bool isDarkMode;
+  final ValueNotifier<bool> isDarkModeNotifier;
 
   const CustomDrawer({
     super.key,
     required this.onThemeToggle,
-    required this.isDarkMode,
+    required this.isDarkModeNotifier,
   });
 
   @override
@@ -17,49 +17,37 @@ class CustomDrawer extends StatefulWidget {
 }
 
 class _CustomDrawerState extends State<CustomDrawer> {
-  late bool isDarkMode;
-
-  @override
-  void initState() {
-    super.initState();
-    // Inicializa o estado do tema conforme o valor passado do pai
-    isDarkMode = widget.isDarkMode;
-  }
-
   @override
   void didUpdateWidget(covariant CustomDrawer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // Se o valor do tema for atualizado, sincroniza o estado
-    if (oldWidget.isDarkMode != widget.isDarkMode) {
-      setState(() {
-        isDarkMode = widget.isDarkMode;
-      });
-    }
   }
 
   void _handleThemeToggle(bool value) {
-    setState(() {
-      isDarkMode = value;
-    });
+    widget.isDarkModeNotifier.value = value;
     widget.onThemeToggle(value); // Chama o callback para alterar o tema global
   }
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.6,
-      child: Drawer(
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        child: Column(
-          children: [
-            _buildMenuHeader(),
-            _buildThemeToggle(),
-            _buildLogoutButton(),
-            const Spacer(),
-            _buildAppVersionInfo(),
-          ],
-        ),
-      ),
+    return ValueListenableBuilder<bool>(
+      valueListenable: widget.isDarkModeNotifier,
+      builder: (context, isDarkMode, _) {
+        return SizedBox(
+          width: MediaQuery.of(context).size.width * 0.6,
+          child: Drawer(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            child: Column(
+              children: [
+                _buildMenuHeader(),
+                _buildThemeToggle(isDarkMode),
+                _buildLogoutButton(),
+                const Spacer(),
+                _buildAppVersionInfo(),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -79,7 +67,7 @@ class _CustomDrawerState extends State<CustomDrawer> {
     );
   }
 
-  Widget _buildThemeToggle() {
+  Widget _buildThemeToggle(bool isDarkMode) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
       child: MouseRegion(
@@ -121,7 +109,7 @@ class _CustomDrawerState extends State<CustomDrawer> {
               MaterialPageRoute(
                 builder: (context) => LoginScreen(
                   onThemeToggle: widget.onThemeToggle,
-                  isDarkMode: isDarkMode,
+                  isDarkModeNotifier: widget.isDarkModeNotifier,
                 ),
               ),
             );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import file_selector_macos
 import path_provider_foundation
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   file_selector_linux:
     dependency: transitive
     description:
@@ -400,6 +408,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  shared_preferences: ^2.0.15
   google_fonts: ^4.0.3
   cupertino_icons: ^1.0.8
   flutter_svg: ^2.0.7  # Adicione esta linha


### PR DESCRIPTION
- Corrigimos a tela inicial _(StartScreen)_ com animação de transição suave para a tela de login.

- Corrigimos problemas relacionados à sincronização do tema escuro/claro ao alternar entre diferentes telas, garantindo que o estado do botão e o tema estejam sempre consistentes.

- Reformulamos os widgets **CustomDrawer** e **CustomSwitch** para refletirem as atualizações de tema corretamente, mesmo após navegações.

- Ajustamos a navegação entre as telas **HomeScreen**, **ReportScreen** e **LoginScreen** para manter a consistência do estado do tema.