### PR TITLE
PAC-85 | Mudança da cor do appbar de todas as telas

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -74,7 +74,7 @@ class _AppState extends State<App> {
           bodySmall: TextStyle(fontSize: 14, fontWeight: FontWeight.w500, color: Colors.white),
           titleLarge: TextStyle(fontSize: 24, fontWeight: FontWeight.w600, color: Color.fromARGB(255, 255, 255, 255)),
         ),
-        appBarTheme: const AppBarTheme(backgroundColor: Color(0xFF1F1F1F)),
+        appBarTheme: const AppBarTheme(backgroundColor: Color.fromARGB(255, 0, 0, 0)),
         inputDecorationTheme: const InputDecorationTheme(fillColor: Color(0xFF1F1F1F), filled: true),
         iconTheme: const IconThemeData(color: Colors.white),
         colorScheme: const ColorScheme.dark(

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -13,6 +13,7 @@ class CustomDrawer extends StatefulWidget {
   });
 
   @override
+  // ignore: library_private_types_in_public_api
   _CustomDrawerState createState() => _CustomDrawerState();
 }
 
@@ -142,7 +143,7 @@ class _CustomDrawerState extends State<CustomDrawer> {
       child: Align(
         alignment: Alignment.center,
         child: Text(
-          'v.0.3.2',
+          'v.0.3.3',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Colors.white,
               ),


### PR DESCRIPTION
### O que mudou?

Foi simplesmente atualizado a linha `appBarTheme: const AppBarTheme(backgroundColor: Color.fromARGB(255, 0, 0, 0)),` para a cor correta no modo escuro.