### PR TITLE
PAC-81 | Adiciona funcionalidade de navegação entre campos e melhorias no teclado numérico em formulários de cadastro

### DIFF
--- a/lib/screens/create_members.dart
+++ b/lib/screens/create_members.dart
@@ -182,6 +182,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                     child: CustomCapitalizedTextField(
                       controller: nomeCompletoController,
                       hintText: 'Nome Completo',
+                      textInputAction: TextInputAction.next
                     ),
                   ),
                   const SizedBox(height: 20),
@@ -204,6 +205,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                           controller: numeroRolController,
                           hintText: 'Numero de Rol',
                           obscureText: false,
+                          textInputAction: TextInputAction.next,
                           keyboardType: TextInputType.number, // Apenas números
                           inputFormatters: [
                             FilteringTextInputFormatter.digitsOnly,
@@ -237,6 +239,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                     cityController: cidadeNascimentoController,
                     stateController: estadoNascimentoController,
                     obscureText: false,
+                    textInputAction: TextInputAction.next,
                     onCityChanged: (value) {
                       final capitalized = capitalize(value);
                       if (capitalized != value) {
@@ -252,22 +255,26 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                   const SizedBox(height: 20),
                   CustomCapitalizedTextField(
                     controller: nomePaiController,
-                    hintText: 'Nome do Pai'
+                    hintText: 'Nome do Pai',
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   CustomCapitalizedTextField(
                     controller: nomeMaeController,
-                    hintText: 'Nome da Mãe'
+                    hintText: 'Nome da Mãe',
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   CustomCapitalizedTextField(
                     controller: escolaridadeController,
-                    hintText: 'Escolaridade'
+                    hintText: 'Escolaridade',
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   CustomCapitalizedTextField(
                     controller: profissaoController,
-                    hintText: 'Profissão'
+                    hintText: 'Profissão',
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   CustomTextField(
@@ -275,6 +282,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                     hintText: 'E-mail',
                     obscureText: false,
                     keyboardType: TextInputType.emailAddress, // Teclado de email
+                    textInputAction: TextInputAction.next,
                     validator: (value) {
                       if (value == null || value.isEmpty || !isValidEmail(value)) {
                         return 'Por favor, insira um email válido';
@@ -319,6 +327,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                       Flexible(
                         child: CustomCepTextField(
                           controller: cepController,
+                          textInputAction: TextInputAction.next,
                           onEnderecoEncontrado: (endereco) {
                             setState(() {
                               bairroController.text = endereco['bairro'] ?? '';
@@ -337,6 +346,7 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                           controller: bairroController,
                           hintText: 'Bairro',
                           obscureText: false,
+                          textInputAction: TextInputAction.next,
                         ),
                       ),
                     ],
@@ -346,18 +356,21 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                     controller: enderecotController,
                     hintText: 'Endereço',
                     obscureText: false,
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   CustomTextField(
                     controller: complementoController,
                     hintText: 'Complemento',
                     obscureText: false,
+                    textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 20),
                   LocalField(
                     cityController: cidadeAtualController,
                     stateController: estadoAtualController,
                     obscureText: false,
+                    textInputAction: TextInputAction.next,
                     onCityChanged: (value) {
                       final capitalized = capitalize(value);
                       if (capitalized != value) {
@@ -428,7 +441,8 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                         flex: 2,
                         child: CustomCapitalizedTextField(
                           controller: oficianteBatismoController,
-                          hintText: 'Oficiante'
+                          hintText: 'Oficiante',
+                          textInputAction: TextInputAction.next,
                         ),
                       ),
                     ],
@@ -447,7 +461,8 @@ class _CreateMembersScreenState extends State<CreateMembersScreen> {
                         flex: 2,
                         child: CustomCapitalizedTextField(
                           controller: oficianteProfissaoController,
-                          hintText: 'Oficiante'
+                          hintText: 'Oficiante',
+                          textInputAction: TextInputAction.next,
                         ),
                       ),
                     ],

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -89,6 +89,7 @@ class LoginScreen extends StatelessWidget {
                           controller: loginController,
                           hintText: 'Login',
                           obscureText: false,
+                          textInputAction: TextInputAction.next,
                           icon: SvgPicture.asset(
                             'assets/images/user.svg',
                             height: 24,
@@ -103,6 +104,7 @@ class LoginScreen extends StatelessWidget {
                           controller: passwordController,
                           hintText: 'Senha',
                           obscureText: true,
+                          textInputAction: TextInputAction.done,
                           icon: SvgPicture.asset(
                             'assets/images/lock.svg',
                             height: 23,

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -143,7 +143,7 @@ class _CustomDrawerState extends State<CustomDrawer> {
       child: Align(
         alignment: Alignment.center,
         child: Text(
-          'v.0.4.0',
+          'v.0.4.1',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: Colors.white,
               ),

--- a/lib/widgets/local.dart
+++ b/lib/widgets/local.dart
@@ -49,7 +49,7 @@ class LocalField extends StatefulWidget {
     this.icon,
     this.cityLabelText = 'Cidade', // Define valores padrão
     this.stateLabelText = 'UF',
-        this.onCityChanged, // Callback opcional para o campo cidade
+        this.onCityChanged, required TextInputAction textInputAction, // Callback opcional para o campo cidade
 
   });
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -312,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  keyboard_actions:
+    dependency: "direct main"
+    description:
+      name: keyboard_actions
+      sha256: "31e0ab2a706ac8f58887efa60efc1f19aecdf37d8ab0f665a0f156d1fbeab650"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter_multi_formatter: ^2.0.0 # Atualize para a versão mais recente disponível
   http: ^0.13.4
   mask_text_input_formatter: ^2.0.0
+  keyboard_actions: ^4.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Nesta atualização, implementamos a funcionalidade de navegação para o próximo campo nos formulários de cadastro, utilizando a ação “Próximo” nos teclados de texto.

Principais mudanças:

- Implementação da navegação entre campos no formulário com `TextInputAction.next` para os teclados compatíveis.
- Revisão dos componentes de entrada de dados (`CustomTextField`, `CustomCapitalizedTextField`, etc.) para garantir uma experiência de usuário consistente e eficiente em todo o aplicativo.

Essas melhorias proporcionam uma experiência de preenchimento mais fácil e intuitiva, garantindo que o formulário seja mais acessível e agradável para o usuário final.